### PR TITLE
Haskell speedup

### DIFF
--- a/haskell/haskell-k-nn.hs
+++ b/haskell/haskell-k-nn.hs
@@ -25,16 +25,12 @@ main = do
         correct = V.zipWith score results validation
      in print (fromIntegral (V.sum correct) / fromIntegral n)
 
-dist :: Observation -> Observation -> Int
-dist o1 o2 = U.sum $ U.map (^2) $ U.zipWith (-) f1 f2 where
-    (f1, f2) = (features o1, features o2)
-
-closestTo :: Observation -> Observation -> Observation -> Ordering
-closestTo target o1 o2 = compare (dist target o1) (dist target o2)
-
 classify :: Observations -> Observation -> Label
 classify training obs = label closest where
     closest = V.minimumBy (closestTo obs) training
+    closestTo target o1 o2 = compare (dist target o1) (dist target o2)
+    dist o1 o2 = vdist (features o1) (features o2)
+    vdist v1 v2 = U.sum $ U.map (^2) $ U.zipWith (-) v1 v2
 
 parseFile :: BS.ByteString -> Observations
 parseFile = V.fromList . observationsOf . wordsOf . linesOf where

--- a/haskell/haskell-k-nn.hs
+++ b/haskell/haskell-k-nn.hs
@@ -3,6 +3,7 @@
 import qualified Data.Csv as CSV
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as U
 
 data Observation = Observation
     { label    :: !Label
@@ -10,8 +11,8 @@ data Observation = Observation
     } deriving (Show, Eq)
 
 type Label = CSV.Field
-type Feature = Integer
-type Features = V.Vector Feature
+type Feature = Int
+type Features = U.Vector Feature
 type Observations = V.Vector Observation
 
 main = do
@@ -30,8 +31,8 @@ runClassifier validation training =
         correct = V.zipWith score results validation
      in print (fromIntegral (V.sum correct) / fromIntegral n)
 
-dist :: Observation -> Observation -> Integer
-dist o1 o2 = V.sum $ V.map (^2) $ V.zipWith (-) f1 f2 where
+dist :: Observation -> Observation -> Int
+dist o1 o2 = U.sum $ U.map (^2) $ U.zipWith (-) f1 f2 where
     (f1, f2) = (features o1, features o2)
 
 closestTo :: Observation -> Observation -> Observation -> Ordering
@@ -47,4 +48,4 @@ parseRecords = CSV.decode CSV.HasHeader
 instance CSV.FromRecord Observation where
     parseRecord v = do
         pixels <- V.mapM CSV.parseField (V.tail v)
-        return $ Observation (V.head v) pixels
+        return $ Observation (V.head v) (U.convert pixels)

--- a/haskell/haskell-k-nn.hs
+++ b/haskell/haskell-k-nn.hs
@@ -4,6 +4,7 @@ import qualified Data.Csv as CSV
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
+import qualified Control.Parallel.Strategies as P
 
 data Observation = Observation
     { label    :: !Label
@@ -26,7 +27,8 @@ main = do
 runClassifier :: Observations -> Observations -> IO ()
 runClassifier validation training =
     let n = V.length validation
-        results = V.map (classify training) validation
+        inParallel = P.withStrategy (P.parTraversable P.rpar)
+        results = inParallel $ V.map (classify training) validation
         score l o = if l == label o then 1 else 0
         correct = V.zipWith score results validation
      in print (fromIntegral (V.sum correct) / fromIntegral n)


### PR DESCRIPTION
I happened upon your blog and thought for the benefit of future readers that I'd recommend some modifications to the Haskell example. I've cleaned up the code a bit, but also sped it up significantly with some low-hanging gains. The two main changes are using unboxed vectors for the features, and evaluating the training samples in parallel.

Each commit is designed to be read on its own, especially the second two - the first one simply reformats the code rather than making substantial changes.

Compiling with `ghc -threaded -O2`, the program ran in 9s for me (the fast Go program runs in ~1s). I have a 6-core machine so I ran the Haskell code with `./haskell-k-nn +RTS -N6`.

EDIT: Oh, and the new code requires a `cabal install parallel` for the parallel evaluation.

EDIT: I replaced the CSV library with a pretty naive hand-writen parser and the time is now down to 3.5s.
